### PR TITLE
监听其他分区摩天大楼

### DIFF
--- a/bilive/@types/bilive.d.ts
+++ b/bilive/@types/bilive.d.ts
@@ -1,7 +1,7 @@
 // index
 /**
  * 应用设置
- * 
+ *
  * @interface options
  */
 interface _options {
@@ -87,7 +87,7 @@ interface configInfoData {
 // bilive_client
 /**
  * 消息格式
- * 
+ *
  * @interface message
  */
 interface message {
@@ -97,7 +97,7 @@ interface message {
 }
 /**
  * 抽奖raffle信息
- * 
+ *
  * @interface raffleMSG
  * @extends {message}
  */
@@ -107,7 +107,7 @@ interface raffleMSG extends message {
 }
 /**
  * 抽奖lottery信息
- * 
+ *
  * @interface lotteryMSG
  * @extends {message}
  */
@@ -117,8 +117,27 @@ interface lotteryMSG extends message {
 }
 // listener
 /**
+ * AppList
+ *
+ * @interface AppList
+ */
+interface AppList {
+  code: number
+  msg: string
+  data: AppListres
+}
+interface AppListres {
+  module_list: Appmodules[]
+}
+interface Appmodules {
+  list: AppRecommend[]
+}
+interface AppRecommend {
+  roomid: number
+}
+/**
  * 抽奖raffle检查
- * 
+ *
  * @interface raffleCheck
  */
 interface raffleCheck {
@@ -142,7 +161,7 @@ interface raffleCheckData {
 }
 /**
  * 抽奖lottery检查
- * 
+ *
  * @interface lotteryCheck
  */
 interface lotteryCheck {
@@ -188,7 +207,7 @@ interface lotteryCheckDataSender {
 // raffle
 /**
  * 抽奖设置
- * 
+ *
  * @interface raffleOptions
  */
 interface raffleOptions {
@@ -200,7 +219,7 @@ interface raffleOptions {
 }
 /**
  * 参与抽奖信息
- * 
+ *
  * @interface raffleJoin
  */
 interface raffleJoin {
@@ -220,7 +239,7 @@ interface raffleJoinData {
 }
 /**
  * 抽奖结果信息
- * 
+ *
  * @interface raffleReward
  */
 interface raffleReward {
@@ -240,7 +259,7 @@ interface raffleRewardData {
 }
 /**
  * App快速抽奖结果信息
- * 
+ *
  * @interface appLightenReward
  */
 interface appLightenReward {
@@ -255,7 +274,7 @@ interface appLightenRewardData {
 }
 /**
  * 抽奖lottery
- * 
+ *
  * @interface lotteryReward
  */
 interface lotteryReward {
@@ -282,7 +301,7 @@ interface lotteryRewardDataAwardlist {
 // online
 /**
  * 签到信息
- * 
+ *
  * @interface signInfo
  */
 interface signInfo {
@@ -301,7 +320,7 @@ interface signInfoData {
 }
 /**
  * 在线心跳返回
- * 
+ *
  * @interface userOnlineHeart
  */
 interface userOnlineHeart {
@@ -310,7 +329,7 @@ interface userOnlineHeart {
 }
 /**
  * 在线领瓜子宝箱
- * 
+ *
  * @interface currentTask
  */
 interface currentTask {
@@ -326,7 +345,7 @@ interface currentTaskData {
 }
 /**
  * 领瓜子答案提交返回
- * 
+ *
  * @interface award
  */
 interface award {
@@ -341,7 +360,7 @@ interface awardData {
 }
 /**
  * 房间信息app
- * 
+ *
  * @interface roomInfo
  */
 interface roomInfo {
@@ -359,7 +378,7 @@ interface roomInfoDataEvent {
 }
 /**
  * 房间信息
- * 
+ *
  * @interface roomInit
  */
 interface roomInit {
@@ -382,7 +401,7 @@ interface roomInitData {
 }
 /**
  * 分享房间返回
- * 
+ *
  * @interface shareCallback
  */
 interface shareCallback {
@@ -392,7 +411,7 @@ interface shareCallback {
 }
 /**
  * 每日包裹
- * 
+ *
  * @interface getBagGift
  */
 interface getBagGift {
@@ -400,7 +419,7 @@ interface getBagGift {
 }
 /**
  * 包裹信息
- * 
+ *
  * @interface bagInfo
  */
 interface bagInfo {
@@ -425,7 +444,7 @@ interface bagInfoData {
 }
 /**
  * 赠送包裹礼物
- * 
+ *
  * @interface sendBag
  */
 interface sendBag {
@@ -453,7 +472,7 @@ interface sendBagData {
 }
 /**
  * 应援团
- * 
+ *
  * @interface linkGroup
  */
 interface linkGroup {
@@ -478,7 +497,7 @@ interface linkGroupInfo {
 }
 /**
  * 应援团签到返回
- * 
+ *
  * @interface signGroup
  */
 interface signGroup {
@@ -493,7 +512,7 @@ interface signGroupData {
 }
 /**
  * 银瓜子兑换硬币返回
- * 
+ *
  * @interface silver2coin
  */
 interface silver2coin {
@@ -510,7 +529,7 @@ interface silver2coinData {
 }
 /**
  * 每日任务
- * 
+ *
  * @interface taskInfo
  */
 interface taskInfo {
@@ -526,7 +545,7 @@ interface taskInfoDoublewatchinfo {
 }
 /**
  * 兑换扭蛋币
- * 
+ *
  * @interface capsule
  */
 interface capsule {
@@ -539,7 +558,7 @@ interface capsuleData {
 }
 /**
  * Server酱
- * 
+ *
  * @interface serverChan
  */
 interface serverChan {

--- a/bilive/listener.ts
+++ b/bilive/listener.ts
@@ -1,4 +1,5 @@
 import request from 'request'
+import cheerio from 'cheerio'
 import { EventEmitter } from 'events'
 import tools from './lib/tools'
 import AppClient from './lib/app_client'
@@ -6,7 +7,7 @@ import DMclient from './dm_client_re'
 import { liveOrigin, apiLiveOrigin, smallTVPathname, rafflePathname, _options } from './index'
 /**
  * 监听服务器消息
- * 
+ *
  * @class Listener
  * @extends {EventEmitter}
  */
@@ -16,7 +17,7 @@ class Listener extends EventEmitter {
   }
   /**
    * 用于接收弹幕消息
-   * 
+   *
    * @private
    * @type {DMclient}
    * @memberof Listener
@@ -24,7 +25,7 @@ class Listener extends EventEmitter {
   private _DMclient!: DMclient
   /**
    * 小电视ID
-   * 
+   *
    * @private
    * @type {number}
    * @memberof Listener
@@ -32,7 +33,7 @@ class Listener extends EventEmitter {
   private _smallTVID: number = 0
   /**
    * 抽奖ID
-   * 
+   *
    * @private
    * @type {number}
    * @memberof Listener
@@ -40,7 +41,7 @@ class Listener extends EventEmitter {
   private _raffleID: number = 0
   /**
    * 快速抽奖ID
-   * 
+   *
    * @private
    * @type {number}
    * @memberof Listener
@@ -48,7 +49,7 @@ class Listener extends EventEmitter {
   private _lotteryID: number = 0
   /**
    * app快速抽奖ID
-   * 
+   *
    * @private
    * @type {number}
    * @memberof Listener
@@ -56,13 +57,15 @@ class Listener extends EventEmitter {
   private _appLightenID: number = 0
   /**
    * 开始监听
-   * 
+   *
    * @memberof Listener
    */
   public Start() {
     const config = _options.config
     const roomID = tools.getLongRoomID(config.defaultRoomID)
     const userID = config.defaultUserID
+    this._PCGamingArea()
+    this._PhoneGamingArea()
     this._DMclient = new DMclient({ roomID, userID })
     this._DMclient
       .on('SYS_MSG', dataJson => this._SYSMSGHandler(dataJson))
@@ -70,8 +73,70 @@ class Listener extends EventEmitter {
       .Connect()
   }
   /**
+   * 获取游戏分区开播房间
+   *
+   * @private
+   *
+   * @memberof Listener
+   */
+  private async _PCGamingArea() {
+    var roomID = 0
+    const Area = await tools.XHR({
+      uri: `http://live.bilibili.com/p/eden/area-tags?parentAreaId=2&areaId=0`,
+      json: true,
+      headers: {'Host': 'live.bilibili.com'}
+    })
+    if (Area !== undefined) {
+      var $ = cheerio.load(Area.body.toString())
+      var roomSID = parseInt($('html').find('ul').children('li')[0].children[0].children[1].children[0].attribs.href.substr(1))
+      roomID = tools.getLongRoomID(roomSID)
+    }
+    const userID = _options.config.defaultUserID
+    this._DMclient = new DMclient({ roomID, userID })
+    tools.Log(`已监听游戏分区房间 `,roomID)
+    this._DMclient
+      .on('SYS_MSG', dataJson => this._SYSMSGHandler2(dataJson))
+      .on('PREPARING', dataJson => {
+        tools.Log(`游戏分区房间 `,dataJson.roomid,` 已下播，切换房间`)
+        this._DMclient.Close()
+        this._PCGamingArea()
+      })
+      .Connect()
+  }
+  /**
+   * 获取手游分区开播房间
+   *
+   * @private
+   *
+   * @memberof Listener
+   */
+  private async _PhoneGamingArea() {
+    var roomID = 0
+    const Area = await tools.XHR({
+      uri: `http://live.bilibili.com/p/eden/area-tags?parentAreaId=3&areaId=0`,
+      json: true,
+      headers: {'Host': 'live.bilibili.com'}
+    })
+    if (Area !== undefined) {
+      var $ = cheerio.load(Area.body.toString())
+      var roomSID = parseInt($('html').find('ul').children('li')[0].children[0].children[1].children[0].attribs.href.substr(1))
+      roomID = tools.getLongRoomID(roomSID)
+    }
+    const userID = _options.config.defaultUserID
+    this._DMclient = new DMclient({ roomID, userID })
+    tools.Log(`已监听手游分区房间 `,roomID)
+    this._DMclient
+      .on('SYS_MSG', dataJson => this._SYSMSGHandler2(dataJson))
+      .on('PREPARING', dataJson => {
+        tools.Log(`手游分区房间 `,dataJson.roomid,` 已下播，切换房间`)
+        this._DMclient.Close()
+        this._PhoneGamingArea()
+      })
+      .Connect()
+  }
+  /**
    * 监听弹幕系统消息
-   * 
+   *
    * @private
    * @param {SYS_MSG} dataJson
    * @memberof Listener
@@ -83,8 +148,21 @@ class Listener extends EventEmitter {
     this._RaffleCheck(url, roomID, 'smallTV')
   }
   /**
+   * 监听非娱乐分区摩天大楼消息
+   *
+   * @private
+   * @param {SYS_MSG} dataJson
+   * @memberof Listener
+   */
+  private _SYSMSGHandler2(dataJson: SYS_MSG) {
+    if (dataJson.real_roomid === undefined || dataJson.tv_id === undefined || dataJson.msg_text.search('摩天大楼') === -1) return
+    const url = apiLiveOrigin + smallTVPathname
+    const roomID = dataJson.real_roomid
+    this._RaffleCheck(url, roomID, 'smallTV')
+  }
+  /**
    * 监听系统礼物消息
-   * 
+   *
    * @private
    * @param {SYS_GIFT} dataJson
    * @memberof Listener
@@ -98,11 +176,11 @@ class Listener extends EventEmitter {
   }
   /**
    * 检查房间抽奖raffle信息
-   * 
+   *
    * @private
-   * @param {string} url 
-   * @param {number} roomID 
-   * @param {('smallTV' | 'raffle')} raffle 
+   * @param {string} url
+   * @param {number} roomID
+   * @param {('smallTV' | 'raffle')} raffle
    * @memberof Listener
    */
   private async _RaffleCheck(url: string, roomID: number, raffle: 'smallTV' | 'raffle') {
@@ -127,10 +205,10 @@ class Listener extends EventEmitter {
   }
   /**
    * 检查房间抽奖lottery信息
-   * 
+   *
    * @private
-   * @param {string} url 
-   * @param {number} roomID 
+   * @param {string} url
+   * @param {number} roomID
    * @memberof Listener
    */
   // @ts-ignore 暂时无用
@@ -156,9 +234,9 @@ class Listener extends EventEmitter {
   }
   /**
    * 检查客户端房间信息
-   * 
+   *
    * @private
-   * @param {number} roomID 
+   * @param {number} roomID
    * @memberof Listener
    */
   private async _AppLightenCheck(roomID: number) {
@@ -184,9 +262,9 @@ class Listener extends EventEmitter {
   }
   /**
    * 监听抽奖消息
-   * 
+   *
    * @private
-   * @param {(raffleMSG | lotteryMSG)} raffleMSG 
+   * @param {(raffleMSG | lotteryMSG)} raffleMSG
    * @memberof Listener
    */
   private _RaffleHandler(raffleMSG: raffleMSG | lotteryMSG) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "typescript": "^2.8.3"
   },
   "dependencies": {
+    "@types/cheerio": "^0.22.7",
+    "cheerio": "^1.0.0-rc.2",
     "request": "^2.85.0",
     "ws": "^5.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
     "typescript": "^2.8.3"
   },
   "dependencies": {
-    "@types/cheerio": "^0.22.7",
-    "cheerio": "^1.0.0-rc.2",
     "request": "^2.85.0",
     "ws": "^5.1.1"
   }


### PR DESCRIPTION
加了一个cheerio模块来解析正在开播的房间列表，因为是解析html所以非常难看...如果有好点的api请大佬无不告知XD
大概就是查询游戏、手游分区已开播房间，监听人气值最高的房间并参与该分区摩天大楼抽奖，监听到下播`cmd: PREPARING`后再次查询房间

老实说，写的不咋地23333